### PR TITLE
Remove initial value of drop down selectors

### DIFF
--- a/pages/FLASHDeconvViewer.py
+++ b/pages/FLASHDeconvViewer.py
@@ -103,45 +103,83 @@ def setSequenceViewInDefaultView():
         DEFAULT_LAYOUT = DEFAULT_LAYOUT + [['sequence_view']] + [['internal_fragment_map']]
 
 
-# page initialization
-params = page_setup()
+def select_experiment():
+    st.session_state.selected_experiment0 = st.session_state.selected_experiment_dropdown
+    if "saved_layout_setting" in st.session_state and len(st.session_state["saved_layout_setting"]) > 1:
+        for exp_index in range(len(st.session_state["saved_layout_setting"])):
+            if exp_index == 0:
+                continue
+            st.session_state[f"selected_experiment{exp_index}"] = st.session_state[f'selected_experiment_dropdown_{exp_index}']
 
-st.title("FLASHViewer")
-setSequenceViewInDefaultView()
 
-### if no input file is given, show blank page
-if "experiment-df" not in st.session_state:
-    st.error('Upload input files first!')
-    sys.exit(0)
+if __name__ == '__main__':
 
-# input experiment file names (for select-box later)
-experiment_df = st.session_state["experiment-df"]
 
-### for only single experiment on one view
-st.selectbox("choose experiment", experiment_df['Experiment Name'], key="selected_experiment0")
-selected_exp0 = experiment_df[experiment_df['Experiment Name'] == st.session_state.selected_experiment0]
-layout_info = DEFAULT_LAYOUT
-if "saved_layout_setting" in st.session_state:  # when layout manager was used
-    layout_info = st.session_state["saved_layout_setting"][0]
-with st.spinner('Loading component...'):
-    sendDataToJS(selected_exp0, layout_info)
+    # page initialization
+    params = page_setup()
 
-### for multiple experiments on one view
-if "saved_layout_setting" in st.session_state and len(st.session_state["saved_layout_setting"]) > 1:
+    st.title("FLASHViewer")
+    setSequenceViewInDefaultView()
 
-    for exp_index, exp_layout in enumerate(st.session_state["saved_layout_setting"]):
-        if exp_index == 0: continue  # skip the first experiment
+    ### if no input file is given, show blank page
+    if "experiment-df" not in st.session_state:
+        st.error('Upload input files first!')
+        sys.exit(0)
 
-        st.divider()  # horizontal line
-        st.selectbox("choose experiment", experiment_df['Experiment Name'],
-                     key="selected_experiment%d" % exp_index,
-                     index=exp_index if exp_index < len(experiment_df) else 0)
-        # if #experiment input files are less than #layouts, all the pre-selection will be the first experiment
+    # input experiment file names (for select-box later)
+    experiment_df = st.session_state["experiment-df"]
 
-        selected_exp = experiment_df[
-            experiment_df['Experiment Name'] == st.session_state["selected_experiment%d" % exp_index]]
-        layout_info = st.session_state["saved_layout_setting"][exp_index]
+    # Map names to index
+    name_to_index = {n : i for i, n in enumerate(experiment_df['Experiment Name'])}
+
+    ### for only single experiment on one view
+    col1, col2 =  st.columns([0.9, 0.1])
+    with col1:
+        st.selectbox(
+            "choose experiment", experiment_df['Experiment Name'], 
+            key="selected_experiment_dropdown", 
+            index=name_to_index[st.session_state.selected_experiment0] if 'selected_experiment0' in st.session_state else None
+        )
+    with col2:
+        st.text('')
+        st.text('')
+        st.button('apply', on_click=select_experiment)
+
+    if 'selected_experiment0' in st.session_state:
+        selected_exp0 = experiment_df[experiment_df['Experiment Name'] == st.session_state.selected_experiment0]
+        layout_info = DEFAULT_LAYOUT
+        if "saved_layout_setting" in st.session_state:  # when layout manager was used
+            layout_info = st.session_state["saved_layout_setting"][0]
         with st.spinner('Loading component...'):
-            sendDataToJS(selected_exp, layout_info, 'flash_viewer_grid_%d' % exp_index)
+            sendDataToJS(selected_exp0, layout_info)
 
-save_params(params)
+
+    ### for multiple experiments on one view
+    if "saved_layout_setting" in st.session_state and len(st.session_state["saved_layout_setting"]) > 1:
+
+        for exp_index, exp_layout in enumerate(st.session_state["saved_layout_setting"]):
+            if exp_index == 0: continue  # skip the first experiment
+
+            st.divider()  # horizontal line
+
+            col1, col2 =  st.columns([0.9, 0.1])
+            with col1:
+                st.selectbox(
+                    "choose experiment", experiment_df['Experiment Name'], 
+                    key=f'selected_experiment_dropdown_{exp_index}',
+                    index = name_to_index[st.session_state[f'selected_experiment{exp_index}']] if f'selected_experiment{exp_index}' in st.session_state else None
+                )
+            with col2:
+                st.text('')
+                st.text('')
+                st.button('apply', on_click=select_experiment, key=f'button_{exp_index}' if exp_index < len(experiment_df) else 0)
+
+            # if #experiment input files are less than #layouts, all the pre-selection will be the first experiment
+            if f"selected_experiment{exp_index}" in st.session_state:
+                selected_exp = experiment_df[
+                    experiment_df['Experiment Name'] == st.session_state["selected_experiment%d" % exp_index]]
+                layout_info = st.session_state["saved_layout_setting"][exp_index]
+                with st.spinner('Loading component...'):
+                    sendDataToJS(selected_exp, layout_info, 'flash_viewer_grid_%d' % exp_index)
+
+    save_params(params)

--- a/pages/FLASHDeconvViewer.py
+++ b/pages/FLASHDeconvViewer.py
@@ -106,9 +106,7 @@ def setSequenceViewInDefaultView():
 def select_experiment():
     st.session_state.selected_experiment0 = st.session_state.selected_experiment_dropdown
     if "saved_layout_setting" in st.session_state and len(st.session_state["saved_layout_setting"]) > 1:
-        for exp_index in range(len(st.session_state["saved_layout_setting"])):
-            if exp_index == 0:
-                continue
+        for exp_index in range(1, len(st.session_state["saved_layout_setting"])):
             st.session_state[f"selected_experiment{exp_index}"] = st.session_state[f'selected_experiment_dropdown_{exp_index}']
 
 

--- a/pages/FLASHTaggerViewer.py
+++ b/pages/FLASHTaggerViewer.py
@@ -186,9 +186,7 @@ def setSequenceViewInDefaultView():
 def select_experiment():
     st.session_state.selected_experiment0_tagger = st.session_state.selected_experiment_dropdown_tagger
     if "saved_layout_setting_tagger" in st.session_state and len(st.session_state["saved_layout_setting_tagger"]) > 1:
-        for exp_index in range(len(st.session_state["saved_layout_setting_tagger"])):
-            if exp_index == 0:
-                continue
+        for exp_index in range(1, len(st.session_state["saved_layout_setting_tagger"])):
             st.session_state[f"selected_experiment{exp_index}_tagger"] = st.session_state[f'selected_experiment_dropdown_{exp_index}_tagger']
 
 

--- a/pages/FLASHTaggerViewer.py
+++ b/pages/FLASHTaggerViewer.py
@@ -194,7 +194,6 @@ def content():
     parseUploadedFiles()
     showUploadedFilesTable()
 
-
     ### if no input file is given, show blank page
     if "experiment-df" not in st.session_state:
         st.error('No results to show yet. Please run a workflow first!')
@@ -204,8 +203,8 @@ def content():
     experiment_df = st.session_state["experiment-df"]
 
     ### for only single experiment on one view
-    st.selectbox("choose experiment", experiment_df['Experiment Name'], key="selected_experiment0")
-    selected_exp0 = experiment_df[experiment_df['Experiment Name'] == st.session_state.selected_experiment0]
+    st.selectbox("choose experiment", experiment_df['Experiment Name'], key="selected_experiment0_tagger")
+    selected_exp0 = experiment_df[experiment_df['Experiment Name'] == st.session_state.selected_experiment0_tagger]
     layout_info = DEFAULT_LAYOUT
     if "saved_layout_setting_tagger" in st.session_state:  # when layout manager was used
         layout_info = st.session_state["saved_layout_setting_tagger"][0]
@@ -220,14 +219,14 @@ def content():
 
             st.divider() # horizontal line
             st.selectbox("choose experiment", experiment_df['Experiment Name'],
-                         key="selected_experiment%d"%exp_index,
+                         key="selected_experiment%d_tagger"%exp_index,
                          index=exp_index if exp_index<len(experiment_df) else 0)
             # if #experiment input files are less than #layouts, all the pre-selection will be the first experiment
 
             selected_exp = experiment_df[
-                experiment_df['Experiment Name'] == st.session_state["selected_experiment%d"%exp_index]]
+                experiment_df['Experiment Name'] == st.session_state["selected_experiment%d_tagger"%exp_index]]
             layout_info = st.session_state["saved_layout_setting_tagger"][exp_index]
-            print(layout_info)
+
             with st.spinner('Loading component...'):
                 sendDataToJS(selected_exp, layout_info, 'flash_viewer_grid_%d' % exp_index)
 

--- a/pages/FileUpload.py
+++ b/pages/FileUpload.py
@@ -222,6 +222,14 @@ if __name__ == '__main__':
             # User needs to click button to upload selected files
             if c2.form_submit_button("Add mzML files to workspace", type="primary"):
                 # Copy uploaded mzML files to deconv-mzML-files directory
+                if 'selected_experiment0' in st.session_state:
+                    del(st.session_state['selected_experiment0'])
+                if "saved_layout_setting" in st.session_state and len(st.session_state["saved_layout_setting"]) > 1:
+                    for exp_index in range(1, len(st.session_state["saved_layout_setting"])):
+                        if f"selected_experiment{exp_index}" in st.session_state:
+                            del(st.session_state[f"selected_experiment{exp_index}"])
+
+
                 if uploaded_file:
                     # A list of files is required, since online allows only single upload, create a list
                     if type(uploaded_file) != list:

--- a/pages/FileUploadTagger.py
+++ b/pages/FileUploadTagger.py
@@ -257,6 +257,14 @@ if __name__ == '__main__':
             _, c2, _ = st.columns(3)
             # User needs to click button to upload selected files
             if c2.form_submit_button("Add files to workspace", type="primary"):
+
+                if 'selected_experiment0_tagger' in st.session_state:
+                    del(st.session_state['selected_experiment0_tagger'])
+                if "saved_layout_setting_tagger" in st.session_state and len(st.session_state["saved_layout_setting_tagger"]) > 1:
+                    for exp_index in range(1, len(st.session_state["saved_layout_setting_tagger"])):
+                        if f"selected_experiment{exp_index}_tagger" in st.session_state:
+                            del(st.session_state[f"selected_experiment{exp_index}_tagger"])
+
                 # Copy uploaded mzML files to deconv-mzML-files directory
                 if uploaded_file:
                     # A list of files is required, since online allows only single upload, create a list

--- a/src/Workflow.py
+++ b/src/Workflow.py
@@ -149,6 +149,14 @@ class TagWorkflow(WorkflowManager):
             )
 
     def pp(self) -> None:
+
+        if 'selected_experiment0_tagger' in st.session_state:
+            del(st.session_state['selected_experiment0_tagger'])
+        if "saved_layout_setting_tagger" in st.session_state and len(st.session_state["saved_layout_setting_tagger"]) > 1:
+            for exp_index in range(1, len(st.session_state["saved_layout_setting_tagger"])):
+                if f"selected_experiment{exp_index}_tagger" in st.session_state:
+                    del(st.session_state[f"selected_experiment{exp_index}_tagger"])
+
         st.session_state['progress_bar_space'] = st.container()
         
         try:
@@ -358,6 +366,14 @@ class DeconvWorkflow(WorkflowManager):
 
 
     def pp(self) -> None:
+
+        if 'selected_experiment0' in st.session_state:
+            del(st.session_state['selected_experiment0'])
+        if "saved_layout_setting" in st.session_state and len(st.session_state["saved_layout_setting"]) > 1:
+            for exp_index in range(1, len(st.session_state["saved_layout_setting"])):
+                if f"selected_experiment{exp_index}" in st.session_state:
+                    del(st.session_state[f"selected_experiment{exp_index}"])
+
         st.session_state['progress_bar_space'] = st.container()
 
         try:


### PR DESCRIPTION
Currently the most recently selected experiment is loaded automatically, which can be time consuming for FV if input files are large. This PR adds an `apply` button which has to be pressed for the viewer component to load.