### PR TITLE
Build windows with dependencies

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -2,9 +2,9 @@ name: Build executable for Windows
 
 on:
   push:
-    branches: [ "main", "TaggerViewerDeploy", "build_windows_with_dependencies"]
+    branches: [ "main", "develop", "TaggerViewerDeploy"]
   pull_request:
-    branches: [ "main", "TaggerViewerDeploy"]
+    branches: [ "main", "develop", "TaggerViewerDeploy"]
 
 # Define needed TOPP tools here
 env:

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -276,12 +276,12 @@ jobs:
       with:
           name: openms-package
           
-    #- name: Compress streamlit_exe folder to OpenMS-App.zip
-    #  run: |
-    #    7z a OpenMS-App.zip ./streamlit_exe/* -r
+    - name: Compress streamlit_exe folder to OpenMS-App.zip
+     run: |
+       7z a OpenMS-App.zip ./streamlit_exe/* -r
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: OpenMS-App
-        path: streamlit_exe
+        path: OpenMS-App.zip

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -175,6 +175,7 @@ jobs:
           SEARCH_ENGINES_DIRECTORY: "${{ github.workspace }}/_thirdparty"
           CI_PROVIDER: "GitHub-Actions"
           PACK_ZIP: 1
+          CPACK_PACKAGE_FILE_NAME: "openms-package"
 
     #- name: Test Windows
     #  shell: bash

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -267,11 +267,10 @@ jobs:
         cp -r js-dist streamlit_exe/js-component/dist
         cp app.py streamlit_exe
 
-        - |
-            IFS=' ' read -r -a files <<< "${TOPP_TOOLS}"
-            for file in "${files[@]}"; do
-              cp "openms-bin/${file}.exe" "streamlit_exe/${file}.exe"
-            done
+        IFS=' ' read -r -a files <<< "${TOPP_TOOLS}"
+        for file in "${files[@]}"; do
+          cp "openms-bin/${file}.exe" "streamlit_exe/${file}.exe"
+        done
 
     - name: Delete OpenMS package artifact
       uses: geekyeggo/delete-artifact@v2

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -2,9 +2,9 @@ name: Build executable for Windows
 
 on:
   push:
-    branches: [ "main", "develop", "TaggerViewerDeploy"]
+    branches: ["develop", "deploy"]
   pull_request:
-    branches: [ "main", "develop", "TaggerViewerDeploy"]
+    branches: ["develop", "deploy"]
 
 # Define needed TOPP tools here
 env:

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -209,7 +209,7 @@ jobs:
         path: js-dist
 
     - name: Download package as artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: openms-package
         path: openms-package

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -175,10 +175,9 @@ jobs:
           ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cipackage.cmake
       env:
           SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
-          PACKAGE_TYPE: nsis
+          PACKAGE_TYPE: zip
           SEARCH_ENGINES_DIRECTORY: "${{ github.workspace }}/_thirdparty"
           CI_PROVIDER: "GitHub-Actions"
-          PACK_ZIP: 1
           CPACK_PACKAGE_FILE_NAME: "openms-package"
 
     #- name: Test Windows

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main", "TaggerViewerDeploy"]
 
+# Define needed TOPP tools here
+env:
+  TOPP_TOOLS: "FLASHDeconv FLASHTnT DecoyDatabase"
+
 jobs:
   build-vue-js-component:
     runs-on: ubuntu-latest
@@ -259,12 +263,13 @@ jobs:
         cp -r example-data streamlit_exe
         cp -r .streamlit streamlit_exe
         cp openms-bin/*.dll streamlit_exe
-        cp openms-bin/FLASHDeconv.exe streamlit_exe
-        cp openms-bin/FLASHTnT.exe streamlit_exe
-        cp openms-bin/DecoyDatabase.exe streamlit_exe
         cp -r share streamlit_exe/share
         cp -r js-dist streamlit_exe/js-component/dist
         cp app.py streamlit_exe
+
+        for file in ${{ env.TOPP_TOOLS }}; do
+            cp "openms-bin/${file}.exe" streamlit_exe
+          done
 
     - name: Delete OpenMS package artifact
       uses: geekyeggo/delete-artifact@v2

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -2,7 +2,7 @@ name: Build executable for Windows
 
 on:
   push:
-    branches: [ "main", "TaggerViewerDeploy"]
+    branches: [ "main", "TaggerViewerDeploy", "build_windows_with_dependencies"]
   pull_request:
     branches: [ "main", "TaggerViewerDeploy"]
 
@@ -165,6 +165,17 @@ jobs:
           CCACHE_COMPRESSLEVEL: 12
           CCACHE_MAXSIZE: 400M
 
+    - name: Package
+      shell: bash
+      run: |
+          ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cipackage.cmake
+      env:
+          SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
+          PACKAGE_TYPE: nsis
+          SEARCH_ENGINES_DIRECTORY: "${{ github.workspace }}/_thirdparty"
+          CI_PROVIDER: "GitHub-Actions"
+          PACK_ZIP: 1
+
     #- name: Test Windows
     #  shell: bash
     #  run: $LAUNCHER ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/citest.cmake
@@ -174,17 +185,11 @@ jobs:
     #     CI_PROVIDER: "GitHub-Actions"
     #     BUILD_NAME: "${{ env.RUN_NAME }}-Win64-class-topp-${{ github.run_number }}"
 
-    - name: Upload TOPP tools as artifact
-      uses: actions/upload-artifact@v3
+    - name: Upload package as artifact
+      uses: actions/upload-artifact@v4
       with:
-        name: OpenMS-bin
-        path: OpenMS/bld/bin
-
-    - name: Upload share as artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: OpenMS-share
-        path: OpenMS/share
+        name: openms-package
+        path: ${{ github.workspace }}/OpenMS/bld/*.zip
 
   build-executable:
     runs-on: windows-latest
@@ -203,17 +208,19 @@ jobs:
         name: vue-js-dist
         path: js-dist
 
-    - name: Download TOPP tools as artifact
+    - name: Download package as artifact
       uses: actions/download-artifact@v3
       with:
-        name: OpenMS-bin
-        path: openms-bin
+        name: openms-package
+        path: openms-package
 
-    - name: Download share as artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: OpenMS-share
-        path: share
+    - name: Extract bin and share from package
+      run: |
+        cd openms-package
+        unzip "*.zip"
+        ls
+        cp -r bin ../openms-bin
+        cp -r share ../share
 
     - name: Setup python embeddable version
       run: |
@@ -253,7 +260,7 @@ jobs:
         cp -r .streamlit streamlit_exe
         cp openms-bin/*.dll streamlit_exe
         cp openms-bin/FLASHDeconv.exe streamlit_exe
-        cp openms-bin/FLASHTagger.exe streamlit_exe
+        cp openms-bin/FLASHTnT.exe streamlit_exe
         cp openms-bin/DecoyDatabase.exe streamlit_exe
         cp -r share streamlit_exe/share
         cp -r js-dist streamlit_exe/js-component/dist

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -277,8 +277,8 @@ jobs:
           name: openms-package
           
     - name: Compress streamlit_exe folder to OpenMS-App.zip
-     run: |
-       7z a OpenMS-App.zip ./streamlit_exe/* -r
+      run: |
+        7z a OpenMS-App.zip ./streamlit_exe/* -r
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -267,9 +267,11 @@ jobs:
         cp -r js-dist streamlit_exe/js-component/dist
         cp app.py streamlit_exe
 
-        for file in ${{ env.TOPP_TOOLS }}; do
-            cp "openms-bin/${file}.exe" streamlit_exe
-          done
+        - |
+            IFS=' ' read -r -a files <<< "${TOPP_TOOLS}"
+            for file in "${files[@]}"; do
+              cp "openms-bin/${file}.exe" "streamlit_exe/${file}.exe"
+            done
 
     - name: Delete OpenMS package artifact
       uses: geekyeggo/delete-artifact@v2

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -267,10 +267,10 @@ jobs:
         cp -r js-dist streamlit_exe/js-component/dist
         cp app.py streamlit_exe
 
-        IFS=' ' read -r -a files <<< "${TOPP_TOOLS}"
-        for file in "${files[@]}"; do
-          cp "openms-bin/${file}.exe" "streamlit_exe/${file}.exe"
-        done
+        $files = $env:TOPP_TOOLS -split ' '
+        foreach ($file in $files) {
+          Copy-Item "openms-bin/${file}.exe" -Destination "streamlit_exe/${file}.exe"
+        }
 
     - name: Delete OpenMS package artifact
       uses: geekyeggo/delete-artifact@v2

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -272,7 +272,7 @@ jobs:
         }
 
     - name: Delete OpenMS package artifact
-      uses: geekyeggo/delete-artifact@v2
+      uses: geekyeggo/delete-artifact@v5
       with:
           name: openms-package
           
@@ -281,7 +281,7 @@ jobs:
     #    7z a OpenMS-App.zip ./streamlit_exe/* -r
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: OpenMS-App
         path: streamlit_exe

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -218,10 +218,9 @@ jobs:
     - name: Extract bin and share from package
       run: |
         cd openms-package
-        unzip "*.zip"
-        ls
-        cp -r bin ../openms-bin
-        cp -r share ../share
+        unzip "*.zip" -d .
+        cp -r openms-package/bin ../openms-bin
+        cp -r openms-package/share ../share
 
     - name: Setup python embeddable version
       run: |
@@ -267,15 +266,10 @@ jobs:
         cp -r js-dist streamlit_exe/js-component/dist
         cp app.py streamlit_exe
 
-    - name: Delete OpenMS bin artifact
+    - name: Delete OpenMS package artifact
       uses: geekyeggo/delete-artifact@v2
       with:
-          name: OpenMS-bin
-
-    - name: Delete OpenMS share artifact
-      uses: geekyeggo/delete-artifact@v2
-      with:
-          name: OpenMS-share
+          name: openms-package
           
     #- name: Compress streamlit_exe folder to OpenMS-App.zip
     #  run: |


### PR DESCRIPTION
This PR adds two things

1) Required TOPP tools can be configured in a list at the top of the `build-windows-executable-app.yaml`.
2) All dependencies are installed in a portable format.