### PR TITLE
Only send relevant data to Vue.js component.

### DIFF
--- a/pages/FLASHTaggerViewer.py
+++ b/pages/FLASHTaggerViewer.py
@@ -237,7 +237,9 @@ def sendDataToJS(selected_data, layout_info_per_exp, grid_key='flash_viewer_grid
                 continue
 
             dfs.append(tmp_df)
-        data_to_send['per_scan_data'] = pd.concat(dfs, axis=1)
+        combined_dfs = pd.concat(dfs, axis=1)
+        combined_dfs = combined_dfs[np.isin(combined_dfs['Scan'], protein_df['Scan'])]
+        data_to_send['per_scan_data'] = combined_dfs
 
     # Set sequence data
     data_to_send['sequence_data'] = sequence_data

--- a/src/components.py
+++ b/src/components.py
@@ -4,7 +4,7 @@ import streamlit.components.v1 as st_components
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
-_RELEASE = False
+_RELEASE = True
 
 
 def flash_viewer_grid_component(components, data, component_key='flash_viewer_grid'):


### PR DESCRIPTION
This PR ensures that for `FLASHTnT` all scans without results are not send to the vue components. It results in a significant increase in performance for large datasets.